### PR TITLE
Fix problem with multiple map support

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -110,7 +110,7 @@ export default class LegendControl implements IControl {
 
         // (re)Construct pane and replace (if already exist)
         const selector = `mapboxgl-ctrl-legend-pane--${id}`;
-        const prevPane = document.querySelector(`.${selector}`);
+        const prevPane = this._container.querySelector(`.${selector}`);
         const pane = createElement('details', {
           classes: ['mapboxgl-ctrl-legend-pane', selector],
           attributes: { open: prevPane ? prevPane.getAttribute('open') !== null : !collapsed },


### PR DESCRIPTION
If there are multiple maps per document, and if theses maps share a
layer with the same id, scoping the legend pane querySelector to
document instead of the container causes matches across the different
maps. Fix this by restricting the DOM query to the current container.

Fixes #11